### PR TITLE
Added mime type "model/stl"

### DIFF
--- a/stl.thumbnailer
+++ b/stl.thumbnailer
@@ -1,3 +1,3 @@
 [Thumbnailer Entry]
 Exec=/usr/local/bin/stl2png.pl %i %o %s
-MimeType=application/sla;model/x.stl-binary;model/x.stl-ascii;
+MimeType=application/sla;model/x.stl-binary;model/x.stl-ascii;model/stl


### PR DESCRIPTION
Added mime type "model/stl" to the thumbnailer as in Ubuntu 20 stl files are already bound to this mime type.